### PR TITLE
fix bug in densityGradient.C

### DIFF
--- a/src/errorEstimators/densityGradient/densityGradient.C
+++ b/src/errorEstimators/densityGradient/densityGradient.C
@@ -118,8 +118,7 @@ void Foam::errorEstimators::densityGradient::update()
             );
             vectorField drField
             (
-                rho_.mesh().C().boundaryField()[patchi].patchNeighbourField()
-              - rho_.mesh().C().boundaryField()[patchi].patchInternalField()
+                rho_.boundaryField()[patchi].patch().delta()
             );
             vectorField gradRhop
             (


### PR DESCRIPTION
This original statement will casue an error in runtime, if the boundary type is cyclic.
related isssue: #3 