### PR TITLE
Compilation

### DIFF
--- a/Allwclean
+++ b/Allwclean
@@ -1,8 +1,9 @@
 #!/bin/sh
-cd ${0%/*} || exit 1    # run from this directory
-set -x
+cd "${0%/*}" || exit                                # Run from this directory
+#------------------------------------------------------------------------------
 
-(cd src && ./Allwclean)
-(cd applications && wclean all)
+src/Allwclean
 
-# ----------------------------------------------------------------- end-of-file
+wclean all applications
+
+#------------------------------------------------------------------------------

--- a/Allwmake
+++ b/Allwmake
@@ -1,13 +1,11 @@
 #!/bin/sh
-cd ${0%/*} || exit 1    # run from this directory
+cd "${0%/*}" || exit                                # Run from this directory
+. "${WM_PROJECT_DIR:?}"/wmake/scripts/AllwmakeParseArguments
 
-# Parse arguments for library compilation
-. $WM_PROJECT_DIR/wmake/scripts/AllwmakeParseArguments
+#------------------------------------------------------------------------------
 
-# (wmake libso BCs && wmake && wmake rhoCentralDyMFoam)
-
-(cd src && wmake all)
+src/Allwmake $targetType $*
 
 wmake all applications
 
-# ----------------------------------------------------------------- end-of-file
+# -----------------------------------------------------------------------------

--- a/etc/bashrc
+++ b/etc/bashrc
@@ -1,9 +1,11 @@
 #----------------------------------*-sh-*--------------------------------------
 # =========                 |
 # \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
-#  \\    /   O peration     | Website:  https://openfoam.org
-#   \\  /    A nd           | Copyright (C) 2020 Synthetik Applied Technologies
+#  \\    /   O peration     |
+#   \\  /    A nd           | www.synthetik-technologies.com
 #    \\/     M anipulation  |
+#------------------------------------------------------------------------------
+#     Copyright (C) 2020 Synthetik Applied Technologies
 #------------------------------------------------------------------------------
 # License
 #     This file is derivative work of OpenFOAM.
@@ -31,6 +33,9 @@
 #
 #------------------------------------------------------------------------------
 
+# Some compatibility methods (OPENFOAM-v2012 and later or Oct-2020 develop)
+export FOAM_EXTRA_CXXFLAGS="-DCOMPAT_OPENFOAM_ORG"
+
 export BLAST_PROJECT=blastfoam
 
 ################################################################################
@@ -41,17 +46,19 @@ export BLAST_PROJECT=blastfoam
 #
 # Please set to the appropriate path if the default is not correct.
 #
-export BLAST_DIR=$HOME/$WM_PROJECT/$BLAST_PROJECT
+export BLAST_DIR="$HOME/$WM_PROJECT/$BLAST_PROJECT"
 
-export BLAST_LIBBIN=$FOAM_USER_LIBBIN
-export BLAST_APPBIN=$FOAM_USER_APPBIN
-#export BLAST_LIBBIN=$FOAM_SITE_LIBBIN
-#export BLAST_APPBIN=$FOAM_SITE_APPBIN
+export BLAST_LIBBIN="$FOAM_USER_LIBBIN"
+export BLAST_APPBIN="$FOAM_USER_APPBIN"
+#export BLAST_LIBBIN="$FOAM_SITE_LIBBIN"
+#export BLAST_APPBIN="$FOAM_SITE_APPBIN"
 
 # Equation of state template directory
-export EOS_DIR=$BLAST_DIR/etc/equationOfStateData
+export EOS_DIR="$BLAST_DIR"/etc/equationOfStateData
 export ADDITIONAL_EOS=
 
 # OpenQBMM install directory
 export QBMM_INST_DIR=
 # export QBMM_DIR=$HOME/$WM_PROJECT/OpenQBMM-dev
+
+#------------------------------------------------------------------------------

--- a/src/Allwclean
+++ b/src/Allwclean
@@ -1,6 +1,7 @@
 #!/bin/sh
-cd ${0%/*} || exit 1    # run from this directory
-set -x
+cd "${0%/*}" || exit                                # Run from this directory
+#------------------------------------------------------------------------------
+# set -x
 
 wclean $targetType thermodynamicModels
 wclean $targetType fluxSchemes
@@ -15,4 +16,4 @@ wclean $targetType functionObjects
 wclean $targetType sampling
 wclean $targetType atmosphereModels
 
-# ----------------------------------------------------------------- end-of-file
+#------------------------------------------------------------------------------

--- a/src/Allwmake
+++ b/src/Allwmake
@@ -1,8 +1,8 @@
 #!/bin/sh
-cd ${0%/*} || exit 1    # run from this directory
+cd "${0%/*}" || exit                                # Run from this directory
+. "${WM_PROJECT_DIR:?}"/wmake/scripts/AllwmakeParseArguments
 
-# Parse arguments for library compilation
-. $WM_PROJECT_DIR/wmake/scripts/AllwmakeParseArguments
+#------------------------------------------------------------------------------
 
 wmake $targetType timeIntegrators
 wmake $targetType thermodynamicModels
@@ -17,5 +17,4 @@ wmake $targetType functionObjects
 wmake $targetType sampling
 wmake $targetType atmosphereModels
 
-# ----------------------------------------------------------------- end-of-file
-
+# -----------------------------------------------------------------------------

--- a/src/atmosphereModels/atmosphereModel/newAtmosphereModel.C
+++ b/src/atmosphereModels/atmosphereModel/newAtmosphereModel.C
@@ -33,7 +33,7 @@ Foam::autoPtr<Foam::atmosphereModel> Foam::atmosphereModel::New
     const dictionary& dict
 )
 {
-    word atmosphereModelType(dict.lookup("type"));
+    const word atmosphereModelType(dict.lookupType<word>("type"));
 
     Info<< "Selecting atmosphereModel: " << atmosphereModelType << endl;
 

--- a/src/decompositionMethods/decompositionMethod/decompositionMethod.C
+++ b/src/decompositionMethods/decompositionMethod/decompositionMethod.C
@@ -81,7 +81,7 @@ Foam::decompositionMethod::decompositionMethod
         {
             const dictionary& dict = iter().dict();
 
-            constraintTypes_.append(dict.lookup("type"));
+            constraintTypes_.append(dict.lookupType<word>("type"));
 
             constraints_.append
             (
@@ -181,7 +181,7 @@ Foam::autoPtr<Foam::decompositionMethod> Foam::decompositionMethod::New
 {
     Pout << " Foam::decompositionMethod::New " << decompositionDict << endl;
 
-    const word methodType(decompositionDict.lookup("method"));
+    const word methodType(decompositionDict.lookupType<word>("method"));
 
     Pout<< "Selecting decompositionMethod " << methodType << endl;
 

--- a/src/decompositionMethods/hierarchGeomDecomp/hierarchGeomDecomp.C
+++ b/src/decompositionMethods/hierarchGeomDecomp/hierarchGeomDecomp.C
@@ -46,7 +46,7 @@ namespace Foam
 
 void Foam::hierarchGeomDecomp::setDecompOrder()
 {
-    const word order(geomDecomDict_.lookup("order"));
+    const word order(geomDecomDict_.lookupType<word>("order"));
 
     if (order.size() != 3)
     {

--- a/src/dynamicFvMesh/dynamicFvMesh/dynamicFvMeshNew.C
+++ b/src/dynamicFvMesh/dynamicFvMesh/dynamicFvMeshNew.C
@@ -32,7 +32,10 @@ Foam::autoPtr<Foam::dynamicFvMesh> Foam::dynamicFvMesh::New(const IOobject& io)
     {
         IOdictionary dict(dictHeader);
 
-        const word dynamicFvMeshTypeName(dict.lookup("dynamicFvMesh"));
+        const word dynamicFvMeshTypeName
+        (
+            dict.lookupType<word>("dynamicFvMesh")
+        );
 
         Info<< "Selecting dynamicFvMesh " << dynamicFvMeshTypeName << endl;
 

--- a/src/dynamicMesh/meshCut/directions/directions.C
+++ b/src/dynamicMesh/meshCut/directions/directions.C
@@ -284,7 +284,7 @@ Foam::directions::directions
     List<vectorField>(wordList(dict.lookup("directions")).size())
 {
     const wordList wantedDirs(dict.lookup("directions"));
-    const word coordSystem(dict.lookup("coordinateSystem"));
+    const word coordSystem(dict.lookupType<word>("coordinateSystem"));
 
     bool wantNormal = false;
     bool wantTan1 = false;
@@ -349,7 +349,7 @@ Foam::directions::directions
     {
         const dictionary& patchDict = dict.subDict("patchLocalCoeffs");
 
-        const word patchName(patchDict.lookup("patch"));
+        const word patchName(patchDict.lookupType<word>("patch"));
 
         const label patchi = mesh.boundaryMesh().findPatchID(patchName);
 

--- a/src/dynamicMesh/motionSolvers/displacement/layeredSolver/displacementLayeredMotionMotionSolver.C
+++ b/src/dynamicMesh/motionSolvers/displacement/layeredSolver/displacementLayeredMotionMotionSolver.C
@@ -225,7 +225,7 @@ Foam::displacementLayeredMotionMotionSolver::faceZoneEvaluate
     tmp<vectorField> tfld(new vectorField(meshPoints.size()));
     vectorField& fld = tfld.ref();
 
-    const word type(dict.lookup("type"));
+    const word type(dict.lookupType<word>("type"));
 
     if (type == "fixedValue")
     {
@@ -257,7 +257,7 @@ Foam::displacementLayeredMotionMotionSolver::faceZoneEvaluate
     {
         // Reads name of name of patch. Then get average point dislacement on
         // patch. That becomes the value of fld.
-        const word patchName(dict.lookup("patch"));
+        const word patchName(dict.lookupType<word>("patch"));
         label patchID = mesh().boundaryMesh().findPatchID(patchName);
         pointField pdf
         (
@@ -446,7 +446,10 @@ void Foam::displacementLayeredMotionMotionSolver::cellZoneSolve
     }
 
 
-    const word interpolationScheme = zoneDict.lookup("interpolationScheme");
+    const word interpolationScheme
+    (
+        zoneDict.lookupType<word>("interpolationScheme")
+    );
 
     if (interpolationScheme == "oneSided")
     {

--- a/src/dynamicMesh/motionSolvers/displacement/solidBody/solidBodyMotionFunctions/solidBodyMotionFunction/solidBodyMotionFunctionNew.C
+++ b/src/dynamicMesh/motionSolvers/displacement/solidBody/solidBodyMotionFunctions/solidBodyMotionFunction/solidBodyMotionFunctionNew.C
@@ -33,7 +33,10 @@ Foam::autoPtr<Foam::solidBodyMotionFunction> Foam::solidBodyMotionFunction::New
     const Time& runTime
 )
 {
-    const word motionType(SBMFCoeffs.lookup("solidBodyMotionFunction"));
+    const word motionType
+    (
+        SBMFCoeffs.lookupType<word>("solidBodyMotionFunction")
+    );
 
     Info<< "Selecting solid-body motion function " << motionType << endl;
 

--- a/src/dynamicMesh/polyTopoChange/polyMeshModifier/polyMeshModifierNew.C
+++ b/src/dynamicMesh/polyTopoChange/polyMeshModifier/polyMeshModifierNew.C
@@ -41,7 +41,7 @@ Foam::autoPtr<Foam::polyMeshModifier> Foam::polyMeshModifier::New
         InfoInFunction << "Constructing polyMeshModifier" << endl;
     }
 
-    const word modifierType(dict.lookup("type"));
+    const word modifierType(dict.lookupType<word>("type"));
 
     dictionaryConstructorTable::iterator cstrIter =
         dictionaryConstructorTablePtr_->find(modifierType);

--- a/src/errorEstimators/errorEstimator/newErrorEstimator.C
+++ b/src/errorEstimators/errorEstimator/newErrorEstimator.C
@@ -32,7 +32,7 @@ Foam::autoPtr<Foam::errorEstimator> Foam::errorEstimator::New
     const dictionary& dict
 )
 {
-    word errorEstimatorType(dict.lookup("errorEstimator"));
+    const word errorEstimatorType(dict.lookupType<word>("errorEstimator"));
 
     Info<< "Selecting errorEstimator: " << errorEstimatorType << endl;
 

--- a/src/fluxSchemes/fluxScheme/newFluxScheme.C
+++ b/src/fluxSchemes/fluxScheme/newFluxScheme.C
@@ -32,7 +32,7 @@ Foam::autoPtr<Foam::fluxScheme> Foam::fluxScheme::New
     const fvMesh& mesh
 )
 {
-    word fluxSchemeType(mesh.schemesDict().lookup("fluxScheme"));
+    word fluxSchemeType(mesh.schemesDict().lookupType<word>("fluxScheme"));
 
     Info<< "Selecting fluxScheme: " << fluxSchemeType << endl;
 

--- a/src/radiationModels/absorptionEmissionModels/absorptionEmissionModel/absorptionEmissionModelNew.C
+++ b/src/radiationModels/absorptionEmissionModels/absorptionEmissionModel/absorptionEmissionModelNew.C
@@ -35,7 +35,7 @@ Foam::radiationModels::absorptionEmissionModel::New
     const fvMesh& mesh
 )
 {
-    const word modelType(dict.lookup("absorptionEmissionModel"));
+    const word modelType(dict.lookupType<word>("absorptionEmissionModel"));
 
     Info<< "Selecting absorptionEmissionModel " << modelType << endl;
 

--- a/src/radiationModels/absorptionEmissionModels/wideBand/wideBand.C
+++ b/src/radiationModels/absorptionEmissionModels/wideBand/wideBand.C
@@ -104,7 +104,7 @@ Foam::radiationModels::absorptionEmissionModels::wideBand::wideBand
 
     if (coeffsDict_.found("lookUpTableFileName"))
     {
-        const word name = coeffsDict_.lookup("lookUpTableFileName");
+        const word name(coeffsDict_.lookupType<word>("lookUpTableFileName"));
         if (name != "none")
         {
             lookUpTablePtr_.set

--- a/src/radiationModels/radiationModels/radiationModel/radiationModelNew.C
+++ b/src/radiationModels/radiationModels/radiationModel/radiationModelNew.C
@@ -79,7 +79,7 @@ Foam::autoPtr<Foam::radiationModel> Foam::radiationModel::New
     const volScalarField& T
 )
 {
-    const word modelType(dict.lookup("radiationModel"));
+    const word modelType(dict.lookupType<word>("radiationModel"));
 
     Info<< "Selecting radiationModel " << modelType << endl;
 

--- a/src/radiationModels/scatterModels/scatterModel/scatterModelNew.C
+++ b/src/radiationModels/scatterModels/scatterModel/scatterModelNew.C
@@ -35,7 +35,7 @@ Foam::radiationModels::scatterModel::New
     const fvMesh& mesh
 )
 {
-    const word modelType(dict.lookup("scatterModel"));
+    const word modelType(dict.lookupType<word>("scatterModel"));
 
     Info<< "Selecting scatterModel " << modelType << endl;
 

--- a/src/sampling/sampledSet/sampledSet/sampledSet.C
+++ b/src/sampling/sampledSet/sampledSet/sampledSet.C
@@ -140,7 +140,7 @@ Foam::autoPtr<Foam::sampledSet> Foam::sampledSet::New
     const dictionary& dict
 )
 {
-    const word sampleType(dict.lookup("type"));
+    const word sampleType(dict.lookupType<word>("type"));
 
     const HashTable<word> oldToNewType =
     {

--- a/src/sampling/sampledSurface/sampledSurface/sampledSurface.C
+++ b/src/sampling/sampledSurface/sampledSurface/sampledSurface.C
@@ -120,7 +120,7 @@ Foam::autoPtr<Foam::sampledSurface> Foam::sampledSurface::New
     const dictionary& dict
 )
 {
-    const word sampleType(dict.lookup("type"));
+    const word sampleType(dict.lookupType<word>("type"));
 
     if (debug)
     {

--- a/src/sampling/sampledSurface/sampledSurfaces/sampledSurfaces.C
+++ b/src/sampling/sampledSurface/sampledSurfaces/sampledSurfaces.C
@@ -240,7 +240,7 @@ bool Foam::sampledSurfaces::read(const dictionary& dict)
         dict.lookup("fields") >> fieldSelection_;
 
         dict.lookup("interpolationScheme") >> interpolationScheme_;
-        const word writeType(dict.lookup("surfaceFormat"));
+        const word writeType(dict.lookupType<word>("surfaceFormat"));
 
         // Define the surface formatter
         // Optionally defined extra controls for the output formats

--- a/src/thermodynamicModels/activationModels/activationModel/newActivationModel.C
+++ b/src/thermodynamicModels/activationModels/activationModel/newActivationModel.C
@@ -33,7 +33,7 @@ Foam::autoPtr<Foam::activationModel> Foam::activationModel::New
     const word& phaseName
 )
 {
-    word activationModelType(dict.lookup("activationModel"));
+    const word activationModelType(dict.lookupType<word>("activationModel"));
 
     Info<< "Selecting activationModel: " << activationModelType << endl;
 

--- a/src/thermodynamicModels/basic/fluidThermo/newFluidThermoModel.C
+++ b/src/thermodynamicModels/basic/fluidThermo/newFluidThermoModel.C
@@ -84,7 +84,7 @@ Foam::autoPtr<Foam::fluidThermoModel> Foam::fluidThermoModel::New
     const bool master
 )
 {
-    word type = dict.lookup("type");
+    const word type(dict.lookupType<word>("type"));
     if (type == "basic")
     {
         return NewBasic(phaseName, p, rho, e, T, dict, master);

--- a/src/thermodynamicModels/basic/solidThermo/newSolidThermoModel.C
+++ b/src/thermodynamicModels/basic/solidThermo/newSolidThermoModel.C
@@ -75,7 +75,8 @@ Foam::autoPtr<Foam::solidThermoModel> Foam::solidThermoModel::New
     const bool master
 )
 {
-    word type = dict.subDict("mixture").lookup("type");
+    const word type(dict.subDict("mixture").lookupType<word>("type"));
+
     if (type == "basic")
     {
         return NewBasic(phaseName, mesh, dict, master);

--- a/src/thermodynamicModels/lookupTables/lookupTable2D/lookupTable2D.C
+++ b/src/thermodynamicModels/lookupTables/lookupTable2D/lookupTable2D.C
@@ -61,7 +61,7 @@ void Foam::lookupTable2D::readTable(const fileName& file, Field<scalarField>& da
     DynamicList<Tuple2<scalar, scalar>> values;
 
     bool mergeSeparators_=false;
-    string separator_=';';
+    string separator_(';');
 
     label i = 0;
     while (is.good())

--- a/src/thermodynamicModels/specie/equationOfStates/tabulatedThermoEOS/tabulatedThermoEOS.C
+++ b/src/thermodynamicModels/specie/equationOfStates/tabulatedThermoEOS/tabulatedThermoEOS.C
@@ -40,9 +40,9 @@ Foam::tabulatedThermoEOS<Specie>::tabulatedThermoEOS
     pTable_
     (
         dict.subDict("equationOfState").lookupType<fileName>("file"),
-        dict.subDict("equationOfState").lookup("mod"),
-        dict.subDict("equationOfState").lookup("rhoMod"),
-        dict.subDict("equationOfState").lookup("eMod"),
+        dict.subDict("equationOfState").lookupType<word>("mod"),
+        dict.subDict("equationOfState").lookupType<word>("rhoMod"),
+        dict.subDict("equationOfState").lookupType<word>("eMod"),
         dict.subDict("equationOfState").lookupType<label>("nRho"),
         dict.subDict("equationOfState").lookupType<label>("ne"),
         dict.subDict("equationOfState").lookupType<scalar>("minRho"),
@@ -53,9 +53,9 @@ Foam::tabulatedThermoEOS<Specie>::tabulatedThermoEOS
     TTable_
     (
         dict.subDict("thermodynamics").lookupType<fileName>("file"),
-        dict.subDict("thermodynamics").lookup("mod"),
-        dict.subDict("thermodynamics").lookup("rhoMod"),
-        dict.subDict("thermodynamics").lookup("eMod"),
+        dict.subDict("thermodynamics").lookupType<word>("mod"),
+        dict.subDict("thermodynamics").lookupType<word>("rhoMod"),
+        dict.subDict("thermodynamics").lookupType<word>("eMod"),
         dict.subDict("thermodynamics").lookupType<label>("nRho"),
         dict.subDict("thermodynamics").lookupType<label>("ne"),
         dict.subDict("thermodynamics").lookupType<scalar>("minRho"),

--- a/src/thermodynamicModels/specie/tabulatedThermo/tabulatedThermo.C
+++ b/src/thermodynamicModels/specie/tabulatedThermo/tabulatedThermo.C
@@ -40,9 +40,9 @@ Foam::tabulatedThermo<EquationOfState>::tabulatedThermo
     TTable_
     (
         dict.subDict("thermodynamics").lookupType<fileName>("file"),
-        dict.subDict("thermodynamics").lookup("mod"),
-        dict.subDict("thermodynamics").lookup("rhoMod"),
-        dict.subDict("thermodynamics").lookup("eMod"),
+        dict.subDict("thermodynamics").lookupType<word>("mod"),
+        dict.subDict("thermodynamics").lookupType<word>("rhoMod"),
+        dict.subDict("thermodynamics").lookupType<word>("eMod"),
         dict.subDict("thermodynamics").lookupType<label>("nRho"),
         dict.subDict("thermodynamics").lookupType<label>("ne"),
         dict.subDict("thermodynamics").lookupType<scalar>("minRho"),


### PR DESCRIPTION
Hi @jheylmun - some initial changes for compilation. Clang is especially fussy.

Some _gotchas_.
- in the openfoam.com version, cannot implicitly construct strings from a character, nor from a stream. This means that things like `word foo = is;` will not work. Need to have `word foo(is);'
- similarly with a single character. Need to have `string sep(';');` having implicit construction via assignment is dangerous. It would even allow stupid things like `string sep = 100;`, which clearly doesn't make sense

Not everything compiles yet. Mostly due to the templated `writeEntry` stuff.