### PR TITLE
Replaced erroneous mesh.update call with mesh.move in blastReactingFoam

### DIFF
--- a/applications/solvers/blastReactingFoam/blastReactingFoam.C
+++ b/applications/solvers/blastReactingFoam/blastReactingFoam.C
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
         Info<< "Time = " << runTime.name() << nl << endl;
 
         //- Move the mesh
-        mesh.update();
+        mesh.move();
 
         integrator.integrate();
 


### PR DESCRIPTION
It seems the blastReactingFoam code was erroneously calling mesh.update() instead of mesh.move() here. This lead to failure of both of the tutorial cases for blastReactingFoam when adaptive meshing was enabled.